### PR TITLE
Yii2

### DIFF
--- a/MailgunYii2.php
+++ b/MailgunYii2.php
@@ -1,8 +1,5 @@
 <?php
-
-/** @author Constantin Chuprik */
-
-require_once 'MailgunApi.php';
+/** @author Andrei Baibaratsky */
 
 /**
  * Class MailgunYii2


### PR DESCRIPTION
Обещал давно кинуть, но забывал. В общем-то от компоненты для Yii первой версии особо ничем не отличается, сделал по той же логике. Только классы родители поменялись и немного render().

Реквест по большей части кидаю уточнить один момент. Может тебе стоит для Yii2 в отдельный реп выложить? Так-то сейчас сейчас `require "php": ">=5.2"`, а внутри будет болтаться компонента для фреймворка, который требует php 5.4.
