### PR TITLE
removed $address as index

### DIFF
--- a/MailgunMessage.php
+++ b/MailgunMessage.php
@@ -94,7 +94,7 @@ class MailgunMessage implements MailgunObject
 
         $this->_to[] = array($address, $name);
         if (is_array($recipientVars)) {
-            $this->_recipientVars[$address] = $recipientVars;
+            $this->_recipientVars = $recipientVars;
         }
     }
 


### PR DESCRIPTION
The old code produces this type of JSON which is invalid in MailGun's
batch sending method.
{"testA@gmail.com,
testB@gmail.com":{"testA@gmail.com":{"first":"TestA"},"testB@gmail.com":{"first":"TestB"}}}
![mg-message](https://cloud.githubusercontent.com/assets/19661680/22279082/4ca11f60-e303-11e6-947a-fc579bb8ad5b.png)
